### PR TITLE
pass config file name as param

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -14,7 +15,12 @@ import (
 func main() {
 	logger := log.Default()
 
-	c, err := config.LoadConfig("config.yml")
+	var configFileName string
+	flag.StringVar(&configFileName, "config", "config.yml", "config file name to load")
+
+	flag.Parse()
+
+	c, err := config.LoadConfig(configFileName)
 	if err != nil {
 		logger.Fatalf("failed to load config: %s", err)
 	}


### PR DESCRIPTION
In my use case I do have repositories in multiple organisations and GH projects in each of those organisations as Github projects Beta doesn't support yet adding issues/PRs to a project from repositories outside of the organisation.

At the moment I am keeping different config files for each org, being able to pass the file name as a parameter is handy.

There are other possible solutions to this but I didn't want to over-engineer it being that this is an infrequent scenario.